### PR TITLE
fix: reset UTR on new invoice and use inline overflow style for production scroll

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -74,7 +74,7 @@
         </v-col>
       </v-row>
 
-      <div class="my-0 py-0 overflow-y-auto" style="max-height: 60vh">
+      <div class="my-0 py-0" style="max-height: 60vh; overflow-y: auto">
         <v-data-table :headers="items_headers" :items="items" v-model:expanded="expanded" show-expand
           item-value="posa_row_id" class="elevation-1" :items-per-page="itemsPerPage" expand-on-click
           hide-default-footer>

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -21,7 +21,7 @@
         </v-col>
         <v-col cols="12" class="pt-0 mt-0">
           <div fluid class="items" v-if="items_view == 'card'">
-            <v-row density="default" class="overflow-y-auto" style="max-height: 67vh">
+            <v-row density="default" style="max-height: 67vh; overflow-y: auto">
               <v-col v-for="(item, idx) in filtered_items" :key="idx" xl="2" lg="3" md="6" sm="6" cols="6"
                 min-height="50">
                 <v-card hover="hover" @click="add_item(item)">
@@ -45,7 +45,7 @@
             </v-row>
           </div>
           <div fluid class="items" v-if="items_view == 'list'">
-            <div class="my-0 py-0 overflow-y-auto" style="max-height: 65vh">
+            <div class="my-0 py-0" style="max-height: 65vh; overflow-y: auto">
               <v-data-table :headers="getItemsHeaders()" :items="filtered_items" item-key="item_code" item-value="item-"
                 class="elevation-1" :items-per-page="itemsPerPage" hide-default-footer @click:row="click_item_row">
                 <template v-slot:item.rate="{ item }">

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1459,6 +1459,7 @@ export default {
           });
         }
         this.loyalty_amount = 0;
+        this.utrId = this.invoice_doc.custom_utr || "";
         this.get_addresses();
         this.get_sales_person_names();
 

--- a/posawesome/public/js/posapp/components/pos/PosCoupons.vue
+++ b/posawesome/public/js/posapp/components/pos/PosCoupons.vue
@@ -15,7 +15,7 @@
           </v-col>
         </v-row>
       </v-card-title>
-      <div class="my-0 py-0 overflow-y-auto" style="max-height: 75vh" @mouseover="style = 'cursor: pointer'">
+      <div class="my-0 py-0" style="max-height: 75vh; overflow-y: auto" @mouseover="style = 'cursor: pointer'">
         <v-data-table :headers="items_headers" :items="posa_coupons" :single-expand="singleExpand"
           v-model:expanded="expanded" item-key="coupon" class="elevation-1" :items-per-page="itemsPerPage"
           hide-default-footer>

--- a/posawesome/public/js/posapp/components/pos/PosOffers.vue
+++ b/posawesome/public/js/posapp/components/pos/PosOffers.vue
@@ -4,7 +4,7 @@
       <v-card-title>
         <span class="text-h6 text-primary">{{ __('Offers') }}</span>
       </v-card-title>
-      <div class="my-0 py-0 overflow-y-auto" style="max-height: 75vh" @mouseover="style = 'cursor: pointer'">
+      <div class="my-0 py-0" style="max-height: 75vh; overflow-y: auto" @mouseover="style = 'cursor: pointer'">
         <v-data-table :headers="items_headers" :items="pos_offers" :single-expand="singleExpand"
           v-model:expanded="expanded" show-expand item-key="row_id" class="elevation-1" :items-per-page="itemsPerPage"
           hide-default-footer>

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -18,6 +18,9 @@
             <v-col cols="12" class="pa-1" v-if="dialog_data">
               <v-data-table :headers="headers" :items="dialog_data" item-key="name" class="elevation-1" show-select
                 v-model="selected" select-strategy="single" return-object>
+                <template v-slot:item.item_names="{ item }">
+                  {{ item.items.map(i => i.item_name).join(', ') }}
+                </template>
                 <template v-slot:item.grand_total="{ item }">
                   {{ currencySymbol(item.currency) }}
                   {{ formatCurrency(item.grand_total) }}</template>
@@ -65,6 +68,12 @@ export default {
         value: 'name',
         align: 'start',
         sortable: true,
+      },
+      {
+        title: __('Items'),
+        value: 'item_names',
+        align: 'start',
+        sortable: false,
       },
       {
         title: __('Amount'),

--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -19,7 +19,7 @@
               <v-divider class="p-0 m-0"></v-divider>
             </div>
             <div>
-              <v-row density="default" class="overflow-y-auto" style="max-height: 500px">
+              <v-row density="default" style="max-height: 500px; overflow-y: auto">
                 <v-col v-for="(item, idx) in filterdItems" :key="idx" xl="2" lg="3" md="4" sm="4" cols="6"
                   min-height="50">
                   <v-card hover="hover" @click="add_item(item)">


### PR DESCRIPTION
Demo: https://kommodo.ai/recordings/3GcwrtUSKAClecZbOfhv

UTR field was not being reset when a new invoice loaded, causing it to persist from previous transactions. Added reset in send_invoice_doc_payment handler.

Replaced Vuetify overflow-y-auto utility class with inline overflow-y: auto style across all non-payment scrollable containers. The utility class was not available in production builds where vuetify.min.css fails to load, causing scroll to break on UAT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Items" column to returns listing that shows item names for each return.

* **Bug Fixes**
  * Fixed initialization syncing of custom payment identifier to ensure accurate payment state.

* **Style**
  * Standardized scrolling/overflow handling across invoice, item selector, coupon/offer, and variant views for consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->